### PR TITLE
clarify auto arrange parameter text

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -4867,7 +4867,7 @@ bool GLCanvas3D::_render_arrange_menu(float pos_x)
         settings_changed = true;
     }
 
-    if (imgui->slider_float(_L("Spacing from bed"), &settings.distance_from_bed, dist_bed_min, 100.0f, "%5.2f") || dist_bed_min > settings.distance_from_bed) {
+    if (imgui->slider_float(_L("Spacing from bed edge"), &settings.distance_from_bed, dist_bed_min, 100.0f, "%5.2f") || dist_bed_min > settings.distance_from_bed) {
         settings.distance_from_bed = std::max(dist_bed_min, settings.distance_from_bed);
         settings_out.distance_from_bed = settings.distance_from_bed;
         appcfg->set("arrange", dist_bed_key.c_str(), float_to_string_decimal_point(settings_out.distance_from_bed));


### PR DESCRIPTION
Simple change to make it clear what the second parameter of the arrangement options is.
![screenshot 2024-07-10 at 12 24 44](https://github.com/mmalecki/PrusaSlicer/assets/1847952/76b3dad5-a341-4cef-aae7-27be1727cc56)
